### PR TITLE
Added monad associativity law.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ implement:
 
 1. `m.of(a).chain(f)` is equivalent to `f(a)` (left identity)
 2. `m.chain(m.of)` is equivalent to `m` (right identity)
+3. `m.chain(f).chain(g)` is equivalent to `m.chain(function(x) { return f(x).chain(g); })` (associativity)
 
 
 


### PR DESCRIPTION
Noticed we're not requiring associativity for monads.  Didn't want to just merge this in without some discussion.  Was this just an oversight, or did I miss something?  Also, can someone double check it.
