### PR TITLE
Added Bennu and Akh to implementations.md

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -21,7 +21,9 @@ Here are a list of implementations that live in Fantasy Land:
   Monad
 * [Pirandello](https://github.com/quarterto/Pirandello) better streams, with a MonadPlus
 * [Parsimmon](https://github.com/jayferd/parsimmon) implements parsers that are semigroups, applicative functors, and monads.
-
+* [Bennu](https://github.com/mattbierner/bennu/) parsec style parser combinators implement monad, monoid, functor, and applicative functor.
+* [Akh](https://github.com/mattbierner/akh/) is a collection of monad transformers and common structures that implement Fantasy Land interfaces. 
+ 
 Conforming implementations are encouraged to promote the Fantasy Land logo:
 
 ![](logo.png)


### PR DESCRIPTION
I believe these two libraries implement the fantasy land interfaces. Feel free to verify the interfaces and let me know if there are any problems.

[Bennu fantasy land section](https://github.com/mattbierner/bennu/blob/master/lib/parse.kep#L1003)
