### PR TITLE
Added TsMonad to listed implementations

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -22,8 +22,9 @@ Here are a list of implementations that live in Fantasy Land:
 * [Pirandello](https://github.com/quarterto/Pirandello) better streams, with a MonadPlus
 * [Parsimmon](https://github.com/jayferd/parsimmon) implements parsers that are semigroups, applicative functors, and monads.
 * [Bennu](https://github.com/mattbierner/bennu/) parsec style parser combinators implement monad, monoid, functor, and applicative functor.
-* [Akh](https://github.com/mattbierner/akh/) is a collection of monad transformers and common structures that implement Fantasy Land interfaces. 
- 
+* [Akh](https://github.com/mattbierner/akh/) is a collection of monad transformers and common structures that implement Fantasy Land interfaces.
+* [TsMonad](https://github.com/cbowdon/tsmonad) implements some common monads for TypeScript.
+
 Conforming implementations are encouraged to promote the Fantasy Land logo:
 
 ![](logo.png)


### PR DESCRIPTION
I believe [this](https://github.com/cbowdon/tsmonad) TypeScript library implements the Fantasy Land interface correctly for the Maybe, Either and Writer monads. There are aliases for FL's preferred names for unit/bind/fmap and [test cases](http://cbowdon.github.io/tests/TsMonad/?module=Type%20class%20laws) for the functor and monad laws. If that's not the case let me know, I'll be happy to try and fix it up.
