### PR TITLE
Add creed

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -3,6 +3,7 @@
 Here are a list of implementations that live in Fantasy Land:
 
 * [Most.js](https://github.com/cujojs/most) implements Monoid, Functor, Applicative, and Monad for streams
+* [creed](https://github.com/briancavalier/creed) implements Monoid, Functor, Applicative, and Monad for promises, and interops with Promises/A+ and ES2015 Promise
 * [bacon.js](https://github.com/raimohanska/bacon.js) implements
   Monad and Functor for EventStream and Property on the "fantasy-land" branch
 * [aljebra](https://github.com/markandrus/aljebra) implements common


### PR DESCRIPTION
Been working on this [new coroutine+promise lib](https://github.com/briancavalier/creed) that implements fantasy-land and interops with Promises/A+ and ES2015 promises.  It's promise implements Monoid, Functor, Applicative, and Monad.