### PR TITLE
Set logo width/height to prevent jumps of #hash links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 (aka "Algebraic JavaScript Specification")
 
-![](logo.png)
+<img src="logo.png" width="200" height="200" />
 
 This project specifies interoperability of common algebraic
 structures:


### PR DESCRIPTION
When someone comes to the project page via a #hash link they can end up at a wrong position. Because  after image loaded page height changes at scroll moves. This PR should fix that.