### PR TITLE
Fix derived Foldable.toArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ or its `constructor` object. The `of` method takes one argument:
 
 1. `u.reduce` is equivalent to `u.toArray().reduce`
 
-* `toArray`; derivable as `function() { return this.reduce((acc, x) => acc.concat(x), []); }`
+* `toArray`; derivable as `function() { return this.reduce((acc, x) => acc.concat([x]), []); }`
 
 #### `reduce` method
 


### PR DESCRIPTION
Array.prototype.concat flattens the argument if it is an array, so
concat with a single-element array here.

Hope I am not mistaken?