### PR TITLE
Add the laws implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ implement the Functor specification.
 1. `t(u.sequence(f.of))` is equivalent to `u.map(t).sequence(g.of)`
 where `t` is a natural transformation from `f` to `g` (naturality)
 
-2. `u.map(x => Id(x)).sequence(Id.of)` is equivalent to `Id.of` (identity)
+2. `u.map(x => Id(x)).sequence(Id.of)` is equivalent to `Id.of(u)` (identity)
 
 3. `u.map(Compose).sequence(Compose.of)` is equivalent to
    `Compose(u.sequence(f.of).map(x => x.sequence(g.of)))` (composition)

--- a/id.js
+++ b/id.js
@@ -42,7 +42,7 @@ Id.prototype[fl.ap] = function(b) {
 // Traversable
 Id.prototype[fl.sequence] = function(of) {
     // the of argument is only provided for types where map might fail.
-    return this.value.map(Id.of);
+    return this.value.map(Id[fl.of]);
 };
 
 // Chain

--- a/id.js
+++ b/id.js
@@ -15,13 +15,18 @@ Id.prototype[fl.concat] = function(b) {
 };
 
 // Monoid (value must also be a Monoid)
-Id.prototype[fl.empty] = function() {
+Id[fl.empty] = function() {
     return new Id(this.value[fl.empty] ? this.value[fl.empty]() : this.value.constructor[fl.empty]());
 };
+Id.prototype[fl.empty] = Id[fl.empty];
 
 // Foldable
 Id.prototype[fl.reduce] = function(f, acc) {
     return f(acc, this.value);
+};
+
+Id.prototype.toArray = function() {
+    return [this.value];
 };
 
 // Functor
@@ -54,6 +59,7 @@ Id.prototype[fl.extend] = function(f) {
 Id[fl.of] = function(a) {
     return new Id(a);
 };
+Id.prototype[fl.of] = Id[fl.of];
 
 // Comonad
 Id.prototype[fl.extract] = function() {

--- a/id.js
+++ b/id.js
@@ -60,4 +60,4 @@ Id.prototype[fl.extract] = function() {
     return this.value;
 };
 
-if (typeof module == 'object') module.exports = Id;
+module.exports = Id;

--- a/id_test.js
+++ b/id_test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const applicative = require('./laws/applicative');
+const apply = require('./laws/apply');
+const chain = require('./laws/chain');
+const comonad = require('./laws/comonad');
+
+const Id = require('./id');
+
+const equality = (x, y) => x.equals(y);
+
+exports.applicative = { identity: t => { t.ok(applicative.identity(Id)(equality)(1)); t.done(); }
+                      , homomorphism: t => { t.ok(applicative.homomorphism(Id)(equality)(1)); t.done(); }
+                      , interchange: t => { t.ok(applicative.interchange(Id)(equality)(1)); t.done(); }
+                      };
+
+exports.apply = { composition: t => { t.ok(apply.composition(Id)(equality)(1)); t.done(); } };
+
+exports.chain = { associativity: t => { t.ok(chain.associativity(Id)(equality)(1)); t.done(); } };
+
+exports.comonad = { leftIdentity: t => { t.ok(comonad.leftIdentity(Id.of)(equality)(1)); t.done(); } 
+                  , rightIdentity: t => { t.ok(comonad.rightIdentity(Id.of)(equality)(1)); t.done(); } 
+                  , associativity: t => { t.ok(comonad.associativity(Id.of)(equality)(1)); t.done(); } 
+                  };

--- a/id_test.js
+++ b/id_test.js
@@ -95,6 +95,6 @@ exports.setoid = {
 
 exports.traversable = { 
     naturality: test((x) => traversable.naturality(Id.of)(equality)(Id.of(x))),
-    identity: test((x) => traversable.identity(Id.of)(equality)(Id.of(x))),
+    identity: test((x) => traversable.identity(Id.of)(equality)(x)),
     composition: test((x) => traversable.composition(Id.of)(equality)(Id.of(Sum.of(x))))
 };

--- a/id_test.js
+++ b/id_test.js
@@ -4,21 +4,50 @@ const applicative = require('./laws/applicative');
 const apply = require('./laws/apply');
 const chain = require('./laws/chain');
 const comonad = require('./laws/comonad');
+const extend = require('./laws/extend');
+const foldable = require('./laws/foldable');
+const functor = require('./laws/functor');
+const monad = require('./laws/monad');
+const monoid = require('./laws/monoid');
 
 const Id = require('./id');
 
-const equality = (x, y) => x.equals(y);
+const equality = (x, y) => x.equals ? x.equals(y) : x === y;
 
-exports.applicative = { identity: t => { t.ok(applicative.identity(Id)(equality)(1)); t.done(); }
-                      , homomorphism: t => { t.ok(applicative.homomorphism(Id)(equality)(1)); t.done(); }
-                      , interchange: t => { t.ok(applicative.interchange(Id)(equality)(1)); t.done(); }
-                      };
+exports.applicative =   { 
+    identity: t => { t.ok(applicative.identity(Id)(equality)(1)); t.done(); }, 
+    homomorphism: t => { t.ok(applicative.homomorphism(Id)(equality)(1)); t.done(); }, 
+    interchange: t => { t.ok(applicative.interchange(Id)(equality)(1)); t.done(); }
+};
 
-exports.apply = { composition: t => { t.ok(apply.composition(Id)(equality)(1)); t.done(); } };
+exports.apply = { 
+    composition: t => { t.ok(apply.composition(Id)(equality)(1)); t.done(); } 
+};
 
-exports.chain = { associativity: t => { t.ok(chain.associativity(Id)(equality)(1)); t.done(); } };
+exports.chain = { 
+    associativity: t => { t.ok(chain.associativity(Id)(equality)(1)); t.done(); } 
+};
 
-exports.comonad = { leftIdentity: t => { t.ok(comonad.leftIdentity(Id.of)(equality)(1)); t.done(); } 
-                  , rightIdentity: t => { t.ok(comonad.rightIdentity(Id.of)(equality)(1)); t.done(); } 
-                  , associativity: t => { t.ok(comonad.associativity(Id.of)(equality)(1)); t.done(); } 
-                  };
+exports.comonad = { 
+    leftIdentity: t => { t.ok(comonad.leftIdentity(Id.of)(equality)(1)); t.done(); }, 
+    rightIdentity: t => { t.ok(comonad.rightIdentity(Id.of)(equality)(1)); t.done(); },
+    associativity: t => { t.ok(comonad.associativity(Id.of)(equality)(1)); t.done(); }
+};
+
+exports.extend = { 
+    associativity: t => { t.ok(extend.associativity(Id.of)(equality)(1)); t.done(); } 
+};
+
+exports.foldable = { 
+    associativity: t => { t.ok(foldable.associativity(Id.of)(equality)(1)); t.done(); } 
+};
+
+exports.functor = { 
+    identity: t => { t.ok(functor.identity(Id.of)(equality)(1)); t.done(); },
+    composition: t => { t.ok(functor.composition(Id.of)(equality)(1)); t.done(); }
+};
+
+exports.monad = { 
+    leftIdentity: t => { t.ok(monad.leftIdentity(Id)(equality)(1)); t.done(); },
+    rightIdentity: t => { t.ok(monad.rightIdentity(Id)(equality)(1)); t.done(); }
+};

--- a/laws/applicative.js
+++ b/laws/applicative.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const {identity, apply} = require('fantasy-combinators');
+const {ap} = require('../index');
+
+const id = (t) => (eq) => (x) => {
+    const a = t.of(identity).ap(t.of(x));
+    const b = t.of(x);
+    return eq(a, b);
+};
+
+const homomorphism = (t) => (eq) => (x) => {
+    const a = t.of(identity).ap(t.of(x));
+    const b = t.of(identity(x));
+    return eq(a, b);
+};
+
+const interchange = (t) => (eq) => (x) => {
+    const a = t.of(identity).ap(t.of(x));
+    const b = t.of(apply(t)).ap(t.of(x));
+    return eq(a, b);
+};
+
+modules.exports = { identity: id, homomorphism, interchange };

--- a/laws/applicative.js
+++ b/laws/applicative.js
@@ -1,24 +1,39 @@
 'use strict';
 
-const {identity, apply} = require('fantasy-combinators');
-const {ap} = require('../index');
+const {identity, thrush} = require('fantasy-combinators');
+const {of, ap} = require('..');
 
-const id = (t) => (eq) => (x) => {
-    const a = t.of(identity).ap(t.of(x));
-    const b = t.of(x);
+/**
+
+### Applicative
+
+1. `a.of(x => x).ap(v)` is equivalent to `v` (identity)
+2. `a.of(f).ap(a.of(x))` is equivalent to `a.of(f(x))` (homomorphism)
+3. `u.ap(a.of(y))` is equivalent to `a.of(f => f(y)).ap(u)` (interchange)
+
+**/
+
+const identityʹ = t => eq => x => {
+    const a = t[of](identity).ap(t[of](x));
+    const b = t[of](x);
     return eq(a, b);
 };
 
-const homomorphism = (t) => (eq) => (x) => {
-    const a = t.of(identity).ap(t.of(x));
-    const b = t.of(identity(x));
+const homomorphism = t => eq => x => {
+    const a = t[of](identity).ap(t[of](x));
+    const b = t[of](identity(x));
     return eq(a, b);
 };
 
-const interchange = (t) => (eq) => (x) => {
-    const a = t.of(identity).ap(t.of(x));
-    const b = t.of(apply(t)).ap(t.of(x));
+const interchange = t => eq => x => {
+    const u = t[of](identity);
+
+    const a = u.ap(t[of](x));
+    const b = t[of](thrush(x)).ap(u);
     return eq(a, b);
 };
 
-modules.exports = { identity: id, homomorphism, interchange };
+module.exports = { identity: identityʹ
+                 , homomorphism
+                 , interchange 
+                 };

--- a/laws/apply.js
+++ b/laws/apply.js
@@ -1,14 +1,22 @@
 'use strict';
 
-const {identity, apply} = require('fantasy-combinators');
-const {map, ap} = require('../index');
+const {identity, compose} = require('fantasy-combinators');
+const {of, map, ap} = require('..');
 
-const composition = (t) => (eq) => (x) => {
-    const y = t(x);
+/**
+
+### Apply
+
+1. `a.map(f => g => x => f(g(x))).ap(u).ap(v)` is equivalent to `a.ap(u.ap(v))` (composition)
+
+**/
+
+const composition = t => eq => x => {
+    const y = t[of](identity);
 
     const a = y[map](compose)[ap](y)[ap](y);
     const b = y[ap](y[ap](y));
     return eq(a, b);
 };
 
-modules.exports = { composition };
+module.exports = { composition };

--- a/laws/apply.js
+++ b/laws/apply.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const {identity, apply} = require('fantasy-combinators');
+const {map, ap} = require('../index');
+
+const composition = (t) => (eq) => (x) => {
+    const y = t(x);
+
+    const a = y[map](compose)[ap](y)[ap](y);
+    const b = y[ap](y[ap](y));
+    return eq(a, b);
+};
+
+modules.exports = { composition };

--- a/laws/chain.js
+++ b/laws/chain.js
@@ -1,11 +1,19 @@
 'use strict';
 
-const {chain} = require('../index');
+const {of, chain} = require('..');
 
-const associativity = (t) => (eq) => (x) => {
-    const a = t.of(x)[chain](t.of)[chain](t.of);
-    const b = t.of(x)[chain]((x) => t.of(x).chain(t.of));
+/**
+
+### Chain
+
+1. `m.chain(f).chain(g)` is equivalent to `m.chain(x => f(x).chain(g))` (associativity)
+
+**/
+
+const associativity = t => eq => x => {
+    const a = t[of](x)[chain](t[of])[chain](t[of]);
+    const b = t[of](x)[chain]((x) => t[of](x).chain(t[of]));
     return eq(a, b);
 };
 
-modules.exports = { associativity };
+module.exports = { associativity };

--- a/laws/chain.js
+++ b/laws/chain.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const {chain} = require('../index');
+
+const associativity = (t) => (eq) => (x) => {
+    const a = t.of(x)[chain](t.of)[chain](t.of);
+    const b = t.of(x)[chain]((x) => t.of(x).chain(t.of));
+    return eq(a, b);
+};
+
+modules.exports = { associativity };

--- a/laws/comonad.js
+++ b/laws/comonad.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const {identity} = require('fantasy-combinators');
+const {extend} = require('..');
+
+/**
+
+### Comonad
+
+1. `w.extend(_w => _w.extract())` is equivalent to `w`
+2. `w.extend(f).extract()` is equivalent to `f(w)`
+3. `w.extend(f)` is equivalent to `w.extend(x => x).map(f)`
+
+**/
+
+const leftIdentity = t => eq => x => {
+    const a = t(x).extend(identity).extract();
+    const b = t(x);
+    return eq(a, b);
+};
+
+const rightIdentity = t => eq => x => {
+    const a = t(x).extend(w => w.extract());
+    const b = t(x);
+    return eq(a, b);
+};
+
+const associativity = t => eq => x => {
+    const a = t(x).extend(identity);
+    const b = t(x).extend(identity).map(identity);
+    return eq(a, b);
+};
+
+module.exports = { leftIdentity
+                 , rightIdentity
+                 , associativity
+                 };

--- a/laws/extend.js
+++ b/laws/extend.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const {identity} = require('fantasy-combinators');
+const {extend} = require('..');
+
+/**
+
+### Extend
+
+1. `w.extend(g).extend(f)` is equivalent to `w.extend(_w => f(_w.extend(g)))`
+
+**/
+
+const associativity = t => eq => x => {
+    const a = t(x).extend(identity).extend(identity);
+    const b = t(x).extend(w => identity(w.extend(identity)));
+    return eq(a, b);
+};
+
+module.exports = { associativity };

--- a/laws/foldable.js
+++ b/laws/foldable.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+
+### Foldable
+
+1. `u.reduce` is equivalent to `u.toArray().reduce`
+
+**/
+
+const associativity = t => eq => x => {
+    const a = t.reduce(identity, x);
+    const b = t.toArray().reduce(identity, x);
+    return eq(a, b);
+};
+
+module.exports = { associativity };

--- a/laws/foldable.js
+++ b/laws/foldable.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {identity} = require('fantasy-combinators');
+
 /**
 
 ### Foldable
@@ -9,8 +11,8 @@
 **/
 
 const associativity = t => eq => x => {
-    const a = t.reduce(identity, x);
-    const b = t.toArray().reduce(identity, x);
+    const a = t(x).reduce(identity, x);
+    const b = t(x).toArray().reduce(identity, x);
     return eq(a, b);
 };
 

--- a/laws/functor.js
+++ b/laws/functor.js
@@ -1,18 +1,29 @@
 'use strict';
 
-const {identity, compose} = require('fantasy-combinators');
-const {map} = require('../index');
+const {id: identity, compose} = require('fantasy-combinators');
+const {map} = require('..');
 
-const id =(t) => (eq) => (x) => {
-    const a = t(x)[map](identity);
+/*
+
+### Functor
+
+1. `u.map(a => a)` is equivalent to `u` (identity)
+2. `u.map(x => f(g(x)))` is equivalent to `u.map(g).map(f)` (composition)
+
+*/
+
+const identity = t => eq => x => {
+    const a = t(x)[map](id);
     const b = t(x);
     return eq(a, b);
 };
 
-const composition = (t) => (eq) => (x) => {
-    const a = t(x)[map](compose(identity)(identity));
-    const b = t(x)[map](identity)[map](identity);
+const composition = t => eq => x => {
+    const a = t(x)[map](compose(id)(id));
+    const b = t(x)[map](id)[map](id);
     return eq(a, b);
 };
 
-modules.exports = { identity: id, composition };
+module.exports = { identity
+                 , composition 
+                 };

--- a/laws/functor.js
+++ b/laws/functor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {id: identity, compose} = require('fantasy-combinators');
+const {identity, compose} = require('fantasy-combinators');
 const {map} = require('..');
 
 /*
@@ -12,18 +12,18 @@ const {map} = require('..');
 
 */
 
-const identity = t => eq => x => {
-    const a = t(x)[map](id);
+const identityʹ = t => eq => x => {
+    const a = t(x)[map](identity);
     const b = t(x);
     return eq(a, b);
 };
 
 const composition = t => eq => x => {
-    const a = t(x)[map](compose(id)(id));
-    const b = t(x)[map](id)[map](id);
+    const a = t(x)[map](compose(identity)(identity));
+    const b = t(x)[map](identity)[map](identity);
     return eq(a, b);
 };
 
-module.exports = { identity
+module.exports = { identity: identityʹ
                  , composition 
                  };

--- a/laws/functor.js
+++ b/laws/functor.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const {identity, compose} = require('fantasy-combinators');
+const {map} = require('../index');
+
+const id =(t) => (eq) => (x) => {
+    const a = t(x)[map](identity);
+    const b = t(x);
+    return eq(a, b);
+};
+
+const composition = (t) => (eq) => (x) => {
+    const a = t(x)[map](compose(identity)(identity));
+    const b = t(x)[map](identity)[map](identity);
+    return eq(a, b);
+};
+
+modules.exports = { identity: id, composition };

--- a/laws/monad.js
+++ b/laws/monad.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const {apply} = require('fantasy-combinators');
+const {chain} = require('../index');
+
+const leftIdentity = (t) => (eq) => (x) => {
+    const a = t.of(x)[chain](apply(t.of));
+    const b = apply(t.of)(x);
+    return eq(a, b);
+};
+
+const rightIdentity = (t) => (eq) => (x) => {
+    const a = t.of(x)[chain](t.of);
+    const b = t.of(x);
+    return eq(a, b);
+};
+
+modules.exports = { leftIdentity, rightIdentity };

--- a/laws/monad.js
+++ b/laws/monad.js
@@ -1,18 +1,29 @@
 'use strict';
 
-const {apply} = require('fantasy-combinators');
-const {chain} = require('../index');
+const {identity, apply} = require('fantasy-combinators');
+const {of_: of, chain} = require('..');
 
-const leftIdentity = (t) => (eq) => (x) => {
-    const a = t.of(x)[chain](apply(t.of));
-    const b = apply(t.of)(x);
+/**
+
+### Monad
+
+1. `m.of(a).chain(f)` is equivalent to `f(a)` (left identity)
+2. `m.chain(m.of)` is equivalent to `m` (right identity)
+
+**/
+
+const leftIdentity = t => eq => x => {
+    const a = t[of_](x)[chain](identity);
+    const b = identity(x);
     return eq(a, b);
 };
 
-const rightIdentity = (t) => (eq) => (x) => {
-    const a = t.of(x)[chain](t.of);
-    const b = t.of(x);
+const rightIdentity = t => eq => x => {
+    const a = t[of_](x)[chain](t[of_]);
+    const b = t[of_](x);
     return eq(a, b);
 };
 
-modules.exports = { leftIdentity, rightIdentity };
+module.exports = { leftIdentity
+                 , rightIdentity 
+                 };

--- a/laws/monad.js
+++ b/laws/monad.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {identity, apply} = require('fantasy-combinators');
-const {of_: of, chain} = require('..');
+const {of, chain} = require('..');
 
 /**
 
@@ -13,14 +13,14 @@ const {of_: of, chain} = require('..');
 **/
 
 const leftIdentity = t => eq => x => {
-    const a = t[of_](x)[chain](identity);
+    const a = t[of](x)[chain](identity);
     const b = identity(x);
     return eq(a, b);
 };
 
 const rightIdentity = t => eq => x => {
-    const a = t[of_](x)[chain](t[of_]);
-    const b = t[of_](x);
+    const a = t[of](x)[chain](t[of]);
+    const b = t[of](x);
     return eq(a, b);
 };
 

--- a/laws/monoid.js
+++ b/laws/monoid.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const {identity, apply} = require('fantasy-combinators');
+const {concat} = require('../index');
+
+const rightIdentity = (t) => (eq) => (x) => {
+    const a = t(x)[concat](t.empty());
+    const b = t(x);
+    return eq(a, b);
+};
+
+const leftIdentity = (t) => (eq) => (x) => {
+    const a = t.empty()[concat](t(x));
+    const b = t(x);
+    return eq(a, b);
+};
+
+modules.exports = { rightIdentity, leftIdentity };

--- a/laws/monoid.js
+++ b/laws/monoid.js
@@ -1,18 +1,29 @@
 'use strict';
 
 const {identity, apply} = require('fantasy-combinators');
-const {concat} = require('../index');
+const {concat} = require('..');
 
-const rightIdentity = (t) => (eq) => (x) => {
+/**
+
+### Monoid
+
+1. `m.concat(m.empty())` is equivalent to `m` (right identity)
+2. `m.empty().concat(m)` is equivalent to `m` (left identity)
+
+**/
+
+const rightIdentity = t => eq => x => {
     const a = t(x)[concat](t.empty());
     const b = t(x);
     return eq(a, b);
 };
 
-const leftIdentity = (t) => (eq) => (x) => {
+const leftIdentity = t => eq => x => {
     const a = t.empty()[concat](t(x));
     const b = t(x);
     return eq(a, b);
 };
 
-modules.exports = { rightIdentity, leftIdentity };
+module.exports = { rightIdentity
+                 , leftIdentity 
+                 };

--- a/laws/monoid.js
+++ b/laws/monoid.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {identity, apply} = require('fantasy-combinators');
-const {concat} = require('..');
+const {of, empty, concat} = require('..');
 
 /**
 
@@ -13,14 +13,14 @@ const {concat} = require('..');
 **/
 
 const rightIdentity = t => eq => x => {
-    const a = t(x)[concat](t.empty());
-    const b = t(x);
+    const a = t[of](x)[concat](t[empty]());
+    const b = t[of](x);
     return eq(a, b);
 };
 
 const leftIdentity = t => eq => x => {
-    const a = t.empty()[concat](t(x));
-    const b = t(x);
+    const a = t[empty]()[concat](t[of](x));
+    const b = t[of](x);
     return eq(a, b);
 };
 

--- a/laws/semigroup.js
+++ b/laws/semigroup.js
@@ -1,9 +1,17 @@
 'use strict';
 
 const {identity, apply} = require('fantasy-combinators');
-const {concat} = require('../index');
+const {concat} = require('..');
 
-const associativity = (t) => (eq) => (x) => {
+/**
+
+### Semigroup
+
+1. `a.concat(b).concat(c)` is equivalent to `a.concat(b.concat(c))` (associativity)
+
+**/
+
+const associativity = t => eq => x => {
     const f = t(x);
     const g = t(x);
     const h = t(x);
@@ -13,4 +21,4 @@ const associativity = (t) => (eq) => (x) => {
     return eq(a, b);
 };
 
-modules.exports = { associativity };
+module.exports = { associativity };

--- a/laws/semigroup.js
+++ b/laws/semigroup.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const {identity, apply} = require('fantasy-combinators');
+const {concat} = require('../index');
+
+const associativity = (t) => (eq) => (x) => {
+    const f = t(x);
+    const g = t(x);
+    const h = t(x);
+
+    const a = f[concat](g)[concat](h);
+    const b = f[concat](g[concat](h));
+    return eq(a, b);
+};
+
+modules.exports = { associativity };

--- a/laws/setoid.js
+++ b/laws/setoid.js
@@ -1,9 +1,19 @@
 'use strict';
 
 const {identity, apply} = require('fantasy-combinators');
-const {equals} = require('../index');
+const {equals} = require('..');
 
-const reflexivity = (t) => (eq) => (x) => {
+/**
+
+### Setoid
+
+1. `a.equals(a) === true` (reflexivity)
+2. `a.equals(b) === b.equals(a)` (symmetry)
+3. If `a.equals(b)` and `b.equals(c)`, then `a.equals(c)` (transitivity)
+
+**/
+
+const reflexivity = t => eq => x => {
     const y = t(x);
 
     const a = y[equals](y);
@@ -11,7 +21,7 @@ const reflexivity = (t) => (eq) => (x) => {
     return eq(a, b);
 };
 
-const symmetry = (t) => (eq) => (x) => {
+const symmetry = t => eq => x => {
     const f = t(x);
     const g = t(x);
 
@@ -20,7 +30,7 @@ const symmetry = (t) => (eq) => (x) => {
     return eq(a, b);
 };
 
-const transitivity = (t) => (eq) => (x) => {
+const transitivity = t => eq => x => {
     const f = t(x);
     const g = t(x);
     const h = t(x);
@@ -31,4 +41,7 @@ const transitivity = (t) => (eq) => (x) => {
     return eq(a && b, c);
 };
 
-modules.exports = { reflexivity, symmetry, transitivity };
+module.exports = { reflexivity
+                 , symmetry
+                 , transitivity
+                 };

--- a/laws/setoid.js
+++ b/laws/setoid.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const {identity, apply} = require('fantasy-combinators');
+const {equals} = require('../index');
+
+const reflexivity = (t) => (eq) => (x) => {
+    const y = t(x);
+
+    const a = y[equals](y);
+    const b = true;
+    return eq(a, b);
+};
+
+const symmetry = (t) => (eq) => (x) => {
+    const f = t(x);
+    const g = t(x);
+
+    const a = f[equals](g);
+    const b = g[equals](f);
+    return eq(a, b);
+};
+
+const transitivity = (t) => (eq) => (x) => {
+    const f = t(x);
+    const g = t(x);
+    const h = t(x);
+
+    const a = f[equals](g);
+    const b = g[equals](h);
+    const c = f[equals](h);
+    return eq(a && b, c);
+};
+
+modules.exports = { reflexivity, symmetry, transitivity };

--- a/laws/traversable.js
+++ b/laws/traversable.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const Id = require('../id');
+const {of_, sequence, map} = require('..');
+const {tagged} = require('daggy');
+
+const Compose = tagged('x');
+Compose[of_] = Compose;
+Compose.prototype[map] = function(f) {
+    return Compose(this.x[map](y => y[map](f)));
+};
+
+/*
+
+### Traversable
+
+1. `t(u.sequence(f.of))` is equivalent to `u.map(t).sequence(g.of)`
+where `t` is a natural transformation from `f` to `g` (naturality)
+
+2. `u.map(x => Id(x)).sequence(Id.of)` is equivalent to `Id.of` (identity)
+
+3. `u.map(Compose).sequence(Compose.of)` is equivalent to
+   `Compose(u.sequence(f.of).map(x => x.sequence(g.of)))` (composition)
+
+*/
+
+const naturality = t => eq => x => {
+    const a = id(t(x)[sequence](t[of_]));
+    const b = t(x)[map](id)[sequence](t[of_]);
+    return eq(a, b);
+};
+
+const identity = t => eq => x => {
+    const a = t(x)[map](Id)[sequence](Id[of_]);
+    const b = Id[of_](x);
+    return eq(a, b);
+};
+
+const composition = t => eq => x => {
+    const a = t(x)[map](Compose)[sequence](Compose[of_]);
+    const b = Compose(t(x)[sequence](Id[of_])[map](x => x[sequence](Id[of_])));
+    return eq(a, b);
+};
+
+module.exports = { naturality
+                 , identity 
+                 , composition 
+                 };

--- a/laws/traversable.js
+++ b/laws/traversable.js
@@ -2,7 +2,7 @@
 
 const Id = require('../id');
 const {identity} = require('fantasy-combinators');
-const {of, ap, sequence, map, equals} = require('..');
+const {of, ap, sequence, map, equals, empty, concat} = require('..');
 const {tagged} = require('daggy');
 
 const Compose = tagged('c');
@@ -15,6 +15,17 @@ Compose.prototype[map] = function(f) {
 };
 Compose.prototype[equals] = function(x) {
     return this.c.equals ? this.c.equals(x.c) : this.c === x.c;
+};
+
+Array.prototype[equals] = function(y) {
+    return this.length === y.length && this.join('') === y.join('');
+};
+Array.prototype.sequence = function(p) {
+    return this.reduce((ys, x) => {
+        return identity(x).map(y => z => {
+            return z.concat(y);
+        }).ap(ys);
+    }, p([]));
 };
 
 /*
@@ -38,8 +49,10 @@ const naturality = t => eq => x => {
 };
 
 const identityʹ = t => eq => x => {
-    const a = t(x)[map](identity)[sequence](Id[of]);
-    const b = Id[of](x);
+    const u = [x];
+
+    const a = u[map](Id[of])[sequence](Id[of]);
+    const b = Id[of](u);
     return eq(a, b);
 };
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
   "issues": {
     "url": "https://github.com/fantasyland/fantasy-land/issues"
   },
+  "dependencies": {
+    "daggy": "0.0.x",
+    "fantasy-combinators": "0.0.x"
+  },
+  "devDependencies": {
+    "nodeunit": "0.9.x"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/fantasyland/fantasy-land.git"
@@ -26,5 +33,8 @@
     "id.js",
     "index.js"
   ],
-  "main": "index.js"
+  "main": "index.js",
+  "scripts": {
+    "test": "node --harmony_destructuring node_modules/.bin/nodeunit id_test.js"
+  }
 }


### PR DESCRIPTION
The motivation behind this is to allow any person wanting to implement
any structure that should conform to the specification will also have
the readme and more importantly the implementations of the laws.

The advantage of this as well is that any changes to the spec should be
reflected in the laws folder.