### PR TITLE
Fix for monad identity laws.

### DIFF
--- a/id_test.js
+++ b/id_test.js
@@ -34,6 +34,9 @@ Sum.prototype[equals] = function(x) {
     return this.v.equals ? this.v.equals(x.v) : this.v === x.v;
 };
 
+// Special function for monad identity laws.
+const f = x => Id.of(x + x);
+
 const equality = (x, y) => x.equals ? x.equals(y) : x === y;
 const test = f => t => {
     t.ok(f("x"));
@@ -74,8 +77,8 @@ exports.functor = {
 };
 
 exports.monad = { 
-    leftIdentity: test((x) => monad.leftIdentity(Id)(equality)(x)),
-    rightIdentity: test((x) => monad.rightIdentity(Id)(equality)(x))
+    leftIdentity: test((x) => monad.leftIdentity(Id)(equality)(x)(f)),
+    rightIdentity: test((x) => monad.rightIdentity(Id)(equality)(x)(f))
 };
 
 exports.monoid = { 

--- a/laws/monad.js
+++ b/laws/monad.js
@@ -12,15 +12,15 @@ const {of, chain} = require('..');
 
 **/
 
-const leftIdentity = t => eq => x => {
-    const a = t[of](x)[chain](identity);
-    const b = identity(x);
+const leftIdentity = t => eq => x => f => {
+    const a = t[of](x)[chain](f);
+    const b = f(x);
     return eq(a, b);
 };
 
-const rightIdentity = t => eq => x => {
-    const a = t[of](x)[chain](t[of]);
-    const b = t[of](x);
+const rightIdentity = t => eq => x => f => {
+    const a = f(x)[chain](t[of]);
+    const b = f(x);
     return eq(a, b);
 };
 


### PR DESCRIPTION
I believe there is an issue with the implementation of the identity monad laws. Specifically, the identity function is not a valid argument to `chain`, because it will not return a value of the same Monad (a requirement inherited from Chain).
The reason this has not caused an error so far is because is an implementation detail of the Monad it is tested against. I believe other valid monads can run into issues when testing them against the law in it's current state.

My proposed fix is passing in a monad-returning function `f` to test against instead of using `identity`. I realize this is not such a nice solution in the sense that it changes the API of these tests with regards of the laws of the other tests, so a better solution would be welcome.

The only trivial monad-returning function we could use is `t.of`, but using that would result in identitical `leftIdentity` and `rightIdentity` tests. Another approach is to build a simple `f` in the law file itself, but it would require knowledge of the type of `x`, which would compromise the generality of the test.