### PR TITLE
Make Compose to be a proper Applicative

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,24 +251,24 @@ for any `t` such that `t(a).map(f)` is equivalent to `t(a.map(f))` (naturality)
 
 2. `u.map(F.of).sequence(F.of)` is equivalent to `F.of(u)` for any Applicative `F` (identity)
 
-3. `u.map(Compose.of).sequence(Compose.of)` is equivalent to
-   `Compose.of(u.sequence(f.of).map(x => x.sequence(g.of)))` for Compose type defined below (composition)
+3. `u.map(x => new Compose(x)).sequence(Compose.of)` is equivalent to
+   `new Compose(u.sequence(F.of).map(v => v.sequence(G.of)))` for `Compose` defined below and any Applicatives `F` and `G` (composition)
 
 ```js
 var Compose = function(c) {
   this.c = c;
 };
 
-Compose.of = function(c) {
-  return new Compose(c);
+Compose.of = function(x) {
+  return new Compose(F.of(G.of(x)));
 };
 
 Compose.prototype.ap = function(x) {
-  return Compose.of(this.c.map(u => y => u.ap(y)).ap(x.c));
+  return new Compose(this.c.map(u => y => u.ap(y)).ap(x.c));
 };
 
 Compose.prototype.map = function(f) {
-  return Compose.of(this.c.map(y => y.map(f)));
+  return new Compose(this.c.map(y => y.map(f)));
 };
 ```
 


### PR DESCRIPTION
@joneshf Pointed out that the Compose type as it currently implemented in the spec doesn't pass the Applicative laws. For instance `Compose.of(x => x).ap(Compose.of(1))` will blow up. 

I've also changed the letters that are used for variables and types to hopefully a bit more appropriate ones.

Checked that new code works fine in [Ramda REPL](http://ramdajs.com/repl/#?code=%0Afunction%20IdGenerator%28name%29%20%7B%0A%0A%20%20var%20Id%20%3D%20function%28a%29%20%7B%0A%20%20%20%20this.value%20%3D%20a%3B%0A%20%20%7D%3B%0A%0A%20%20Id.of%20%3D%20function%28a%29%20%7B%0A%20%20%20%20return%20new%20Id%28a%29%3B%0A%20%20%7D%3B%0A%0A%20%20Id.prototype.map%20%3D%20function%28f%29%20%7B%0A%20%20%20%20return%20Id.of%28f%28this.value%29%29%3B%0A%20%20%7D%3B%0A%0A%20%20Id.prototype.ap%20%3D%20function%28b%29%20%7B%0A%20%20%20%20return%20Id.of%28this.value%28b.value%29%29%3B%0A%20%20%7D%3B%0A%0A%20%20Id.prototype.sequence%20%3D%20function%28of%29%20%7B%0A%20%20%20%20return%20this.value.map%28Id.of%29%3B%0A%20%20%7D%3B%0A%0A%20%20Id.prototype.toString%20%3D%20function%28%29%20%7B%0A%20%20%20%20return%20%60%24%7Bname%7D%28%24%7Bthis.value%7D%29%60%0A%20%20%7D%3B%0A%0A%20%20return%20Id%3B%0A%7D%0A%0A%0A%0A%0A%0A%0Aconst%20A%20%3D%20IdGenerator%28%27A%27%29%0Aconst%20B%20%3D%20IdGenerator%28%27B%27%29%0Aconst%20C%20%3D%20IdGenerator%28%27C%27%29%0A%0A%0Avar%20Compose%20%3D%20function%28c%29%20%7B%0A%20%20this.c%20%3D%20c%3B%0A%7D%3B%0A%0ACompose.wrap%20%3D%20function%28c%29%20%7B%0A%20%20return%20new%20Compose%28c%29%0A%7D%3B%0A%0ACompose.of%20%3D%20function%28x%29%20%7B%0A%20%20return%20new%20Compose%28B.of%28C.of%28x%29%29%29%3B%0A%7D%3B%0A%0ACompose.prototype.ap%20%3D%20function%28x%29%20%7B%0A%20%20return%20Compose.wrap%28this.c.map%28u%20%3D%3E%20y%20%3D%3E%20u.ap%28y%29%29.ap%28x.c%29%29%3B%0A%7D%3B%0A%0ACompose.prototype.map%20%3D%20function%28f%29%20%7B%0A%20%20return%20Compose.wrap%28this.c.map%28y%20%3D%3E%20y.map%28f%29%29%29%3B%0A%7D%3B%0A%0ACompose.prototype.toString%20%3D%20function%28%29%20%7B%0A%20%20%2F%2F%20We%20expect%20this.c%20to%20be%20B%28C%28x%29%29%0A%20%20return%20%60Compose%28%24%7Bthis.c.value.value%7D%29%60%0A%7D%3B%0A%0Aconst%20u%20%3D%20A.of%28B.of%28C.of%28100%29%29%29%0A%0Aconst%20expr1%20%3D%20u.map%28Compose.wrap%29.sequence%28Compose.of%29%0Aconst%20expr2%20%3D%20Compose.wrap%28u.sequence%28B.of%29.map%28v%20%3D%3E%20v.sequence%28C.of%29%29%29%0A%0Aconst%20results%20%3D%20%7Bexpr1%2C%20expr2%7D%0Aresults%0A)