### PR TITLE
Flip arguments order in ap

### DIFF
--- a/id.js
+++ b/id.js
@@ -36,7 +36,7 @@ Id.prototype[fl.map] = function(f) {
 
 // Apply
 Id.prototype[fl.ap] = function(b) {
-    return new Id(this.value(b.value));
+    return new Id(b.value(this.value));
 };
 
 // Traversable

--- a/laws/applicative.js
+++ b/laws/applicative.js
@@ -7,20 +7,20 @@ const {of, ap} = require('..');
 
 ### Applicative
 
-1. `a.of(x => x).ap(v)` is equivalent to `v` (identity)
-2. `a.of(f).ap(a.of(x))` is equivalent to `a.of(f(x))` (homomorphism)
-3. `u.ap(a.of(y))` is equivalent to `a.of(f => f(y)).ap(u)` (interchange)
+1. `v.ap(a.of(x => x))` is equivalent to `v` (identity)
+2. `a.of(x).ap(a.of(f))` is equivalent to `a.of(f(x))` (homomorphism)
+3. `a.of(y).ap(u)` is equivalent to `u.ap(a.of(f => f(y)))` (interchange)
 
 **/
 
 const identityʹ = t => eq => x => {
-    const a = t[of](identity)[ap](t[of](x));
+    const a = t[of](x)[ap](t[of](identity));
     const b = t[of](x);
     return eq(a, b);
 };
 
 const homomorphism = t => eq => x => {
-    const a = t[of](identity)[ap](t[of](x));
+    const a = t[of](x)[ap](t[of](identity));
     const b = t[of](identity(x));
     return eq(a, b);
 };
@@ -28,8 +28,8 @@ const homomorphism = t => eq => x => {
 const interchange = t => eq => x => {
     const u = t[of](identity);
 
-    const a = u[ap](t[of](x));
-    const b = t[of](thrush(x))[ap](u);
+    const a = t[of](x)[ap](u);
+    const b = u[ap](t[of](thrush(x)));
     return eq(a, b);
 };
 

--- a/laws/apply.js
+++ b/laws/apply.js
@@ -7,15 +7,15 @@ const {of, map, ap} = require('..');
 
 ### Apply
 
-1. `a.map(f => g => x => f(g(x))).ap(u).ap(v)` is equivalent to `a.ap(u.ap(v))` (composition)
+1. `v.ap(u.ap(a.map(f => g => x => f(g(x)))))` is equivalent to `v.ap(u).ap(a)` (composition)
 
 **/
 
 const composition = t => eq => x => {
     const y = t[of](identity);
 
-    const a = y[map](compose)[ap](y)[ap](y);
-    const b = y[ap](y[ap](y));
+    const a = y[ap](y[ap](y[map](compose)));
+    const b = y[ap](y)[ap](y);
     return eq(a, b);
 };
 

--- a/laws/traversable.js
+++ b/laws/traversable.js
@@ -7,8 +7,8 @@ const {tagged} = require('daggy');
 
 const Compose = tagged('c');
 Compose[of] = Compose;
-Compose.prototype[ap] = function(x) {
-    return Compose(this.c[map](u => y => u[ap](y))[ap](x.c));
+Compose.prototype[ap] = function(f) {
+    return Compose(this.c[ap](f.c[map](u => y => y[ap](u))));
 };
 Compose.prototype[map] = function(f) {
     return Compose(this.c[map](y => y[map](f)));
@@ -25,9 +25,7 @@ Array.prototype[reduce] = Array.prototype.reduce
 Array.prototype[concat] = Array.prototype.concat
 Array.prototype[sequence] = function(p) {
     return this[reduce]((ys, x) => {
-        return identity(x)[map](y => z => {
-            return z[concat](y);
-        })[ap](ys);
+        return ys[ap](identity(x)[map](y => z => z[concat](y)));
     }, p([]));
 };
 


### PR DESCRIPTION
See #50 and #144

This is a breaking change and we have two options how to do it:

 1. Like any other changes that were done before (except they weren't breaking)
 2. Add prefixes to method names (#122) and bump major version number

If we go with the first option there will be a period when some libraries already updated but some not, so they might not work well with each other. For example a code like this may stop working:

```js
import R from 'ramda'
import Foo from 'foo'

a = R.lift(x => y => x + y, Foo.of(1), Foo.of(2))
```

In this case users of libraries will have to freeze their dependencies' versions until all libs are updated.

If we do the second, a user of the libraries will be able to force one that already updated to work in `v0.2` mode, by installing `fantasy-land@0.2.1` instead of `fantasy-land@1.0.0`. But the library that updated will need to support this too, by doing something like:

```js
import fl from 'fantasy-land'

const lift2 = fl.version // supposedly we add .version property in 1.0
  ? (fn, x, y) => x[fl.map](x => y => fn(x, y))[fl.ap](y)
  : (fn, x, y) => y[fl.ap](x[fl.map](x => y => fn(x, y)))

export default lift2
```

Currently PR implements the first option, and I'll be happy to update it to the second if we decide so. And I, for one, think that we should go with the second option.

Whatever we decide, I think we should wait for some time before merging so everybody will have a chance to discuss.