### PR TITLE
Add type signatures to spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ have dependencies on other algebras which must be implemented.
 
 #### `equals` method
 
+```hs
+equals :: Setoid a => a ~> a -> Boolean
+```
+
 A value which has a Setoid must provide an `equals` method. The
 `equals` method takes one argument:
 
@@ -128,6 +132,10 @@ A value which has a Setoid must provide an `equals` method. The
 1. `a.concat(b).concat(c)` is equivalent to `a.concat(b.concat(c))` (associativity)
 
 #### `concat` method
+
+```hs
+concat :: Semigroup a => a ~> a -> a
+```
 
 A value which has a Semigroup must provide a `concat` method. The
 `concat` method takes one argument:
@@ -151,6 +159,10 @@ the Semigroup specification.
 
 #### `empty` method
 
+```hs
+empty :: Monoid m => () -> m
+```
+
 A value which has a Monoid must provide an `empty` method on itself or
 its `constructor` object. The `empty` method takes no arguments:
 
@@ -165,6 +177,10 @@ its `constructor` object. The `empty` method takes no arguments:
 2. `u.map(x => f(g(x)))` is equivalent to `u.map(g).map(f)` (composition)
 
 #### `map` method
+
+```hs
+map :: Functor f => f a ~> (a -> b) -> f b
+```
 
 A value which has a Functor must provide a `map` method. The `map`
 method takes one argument:
@@ -187,6 +203,10 @@ implement the Functor specification.
 1. `a.map(f => g => x => f(g(x))).ap(u).ap(v)` is equivalent to `a.ap(u.ap(v))` (composition)
 
 #### `ap` method
+
+```hs
+ap :: Apply f => f (a -> b) ~> f a -> f b
+```
 
 A value which has an Apply must provide an `ap` method. The `ap`
 method takes one argument:
@@ -214,6 +234,10 @@ implement the Apply specification.
 
 #### `of` method
 
+```hs
+of :: Applicative f => a -> f a
+```
+
 A value which has an Applicative must provide an `of` method on itself
 or its `constructor` object. The `of` method takes one argument:
 
@@ -229,6 +253,10 @@ or its `constructor` object. The `of` method takes one argument:
 1. `u.reduce` is equivalent to `u.reduce((acc, x) => acc.concat([x]), []).reduce`
 
 #### `reduce` method
+
+```hs
+reduce :: Foldable f => f a ~> (b -> a -> b) -> b -> b
+```
 
 A value which has a Foldable must provide a `reduce` method. The `reduce`
 method takes two arguments:
@@ -276,6 +304,10 @@ Compose.prototype.map = function(f) {
 
 #### `sequence` method
 
+```hs
+sequence :: Apply f, Traversable t => t (f a) ~> (b -> f b) -> f (t a)
+```
+
 A value which has a Traversable must provide a `sequence` method. The `sequence`
 method takes one argument:
 
@@ -291,6 +323,10 @@ implement the Apply specification.
 1. `m.chain(f).chain(g)` is equivalent to `m.chain(x => f(x).chain(g))` (associativity)
 
 #### `chain` method
+
+```hs
+chain :: Chain m => m a ~> (a -> m b) -> m b
+```
 
 A value which has a Chain must provide a `chain` method. The `chain`
 method takes one argument:
@@ -319,6 +355,10 @@ the Applicative and Chain specifications.
 
 #### `extend` method
 
+```hs
+extend :: Extend w => w a ~> (w a -> b) -> w b
+```
+
 An Extend must provide an `extend` method. The `extend`
 method takes one argument:
 
@@ -342,6 +382,10 @@ A value that implements the Comonad specification must also implement the Functo
 
 #### `extract` method
 
+```hs
+extract :: Comonad w => w a ~> () -> a
+```
+
 A value which has a Comonad must provide an `extract` method on itself.
 The `extract` method takes no arguments:
 
@@ -359,6 +403,10 @@ the Functor specification.
 2. `p.bimap(a => f(g(a)), b => h(i(b))` is equivalent to `p.bimap(g, i).bimap(f, h)` (composition)
 
 #### `bimap` method
+
+```hs
+bimap :: Bifunctor f => f a c ~> (a -> b) -> (c -> d) -> f b d
+```
 
 A value which has a Bifunctor must provide an `bimap` method. The `bimap`
 method takes two arguments:
@@ -386,6 +434,10 @@ the Functor specification.
 2. `p.promap(a => f(g(a)), b => h(i(b)))` is equivalent to `p.promap(f, i).promap(g, h)` (composition)
 
 #### `promap` method
+
+```hs
+promap :: Profunctor p => p b c ~> (a -> b) -> (c -> d) -> p a d
+```
 
 A value which has a Profunctor must provide a `promap` method.
 


### PR DESCRIPTION
Addresses #138

Throwing this up as a bit of a strawman, as there will no doubt be differing opinions around syntax.

I put forward the following suggestion:
```
sequence :: Apply f, Traversable t => t (f a) ~> (b -> f b) -> f (t a)
'------'    '--------------------'    '-----'    '-------------------'
   '- method name     '- constraints     '- method target  '- method arguments
```

I'm also not sure whether an explanation of the syntax should be included in the spec or not.