### PR TITLE
bower: add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,37 @@
+{
+  "name": "fantasy-land",
+  "description": "Specification for interoperability of common algebraic structures in JavaScript",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/fantasyland/fantasy-land.git"
+  },
+  "main": "index.js",
+  "moduleType": [
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "algebraic",
+    "monad",
+    "applicative",
+    "functor",
+    "monoid",
+    "semigroup",
+    "chain",
+    "apply"
+  ],
+  "ignore": [
+    "/.git/",
+    "/bower_components/",
+    "/figures/",
+    "/laws/",
+    "/node_modules/",
+    "/.*",
+    "/id.js",
+    "/id_test.js",
+    "/implementations.md",
+    "/logo.png",
+    "/package.json"
+  ]
+}


### PR DESCRIPTION
Step 2 of #139

Note that this only exposes __index.js__ since the other JavaScript files depend on fantasy-combinators which is not in the Bower registry.
