### PR TITLE
specify location of ‘empty’ method

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,10 @@ the Semigroup specification.
 empty :: Monoid m => () -> m
 ```
 
-A value which has a Monoid must provide an `empty` method on itself or
-its `constructor` object. The `empty` method takes no arguments:
+A value which has a Monoid must provide an `empty` method. The `empty`
+method takes no arguments:
 
     m.empty()
-    m.constructor.empty()
 
 1. `empty` must return a value of the same Monoid
 

--- a/id.js
+++ b/id.js
@@ -15,10 +15,9 @@ Id.prototype[fl.concat] = function(b) {
 };
 
 // Monoid (value must also be a Monoid)
-Id[fl.empty] = function() {
-    return new Id(this.value[fl.empty] ? this.value[fl.empty]() : this.value.constructor[fl.empty]());
+Id.prototype[fl.empty] = function() {
+    return new Id(this.value[fl.empty]());
 };
-Id.prototype[fl.empty] = Id[fl.empty];
 
 // Foldable
 Id.prototype[fl.reduce] = function(f, acc) {

--- a/id_test.js
+++ b/id_test.js
@@ -22,9 +22,8 @@ const Id = require('./id');
 // Special type of sum for the type of string.
 const Sum = tagged('v');
 Sum[of] = (x) => Sum(x);
-Sum[empty] = () => Sum('');
 Sum.prototype[of] = Sum[of];
-Sum.prototype[empty] = Sum[empty];
+Sum.prototype[empty] = () => Sum('');
 Sum.prototype[map] = function(f) {
     return Sum(f(this.v));
 };
@@ -90,8 +89,8 @@ exports.monad = {
 };
 
 exports.monoid = {
-    leftIdentity: test((x) => monoid.leftIdentity(Id[of](Sum[empty]()))(equality)(Sum[of](x))),
-    rightIdentity: test((x) => monoid.rightIdentity(Id[of](Sum[empty]()))(equality)(Sum[of](x)))
+    leftIdentity: test((x) => monoid.leftIdentity(Id[of](Sum.prototype[empty]()))(equality)(Sum[of](x))),
+    rightIdentity: test((x) => monoid.rightIdentity(Id[of](Sum.prototype[empty]()))(equality)(Sum[of](x)))
 };
 
 // Semigroup tests are broken otherwise for this.


### PR DESCRIPTION
Commit message:

> An instance method is more flexible than a static method. It facilitates
>
> ```javascript
> > Identity([1, 2, 3]).empty()
> Identity([])
> ```
>
> since `Identity#empty` can dispatch to the inner value's `empty` method.
