### PR TITLE
static ‘empty’ value

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,22 +129,21 @@ A value which has a Semigroup must provide a `concat` method. The
 A value that implements the Monoid specification must also implement
 the Semigroup specification.
 
-1. `m.concat(m.empty())` is equivalent to `m` (right identity)
-2. `m.empty().concat(m)` is equivalent to `m` (left identity)
+1. `m.concat(m.constructor.empty)` is equivalent to `m` (right identity)
+2. `m.constructor.empty.concat(m)` is equivalent to `m` (left identity)
 
-#### `empty` method
+#### `empty` value
 
 ```hs
-empty :: Monoid m => () -> m
+empty :: Monoid m => m
 ```
 
-A value which has a Monoid must provide an `empty` method on itself or
-its `constructor` object. The `empty` method takes no arguments:
+A value which has a Monoid must provide an `empty` value on its
+`constructor` object:
 
-    m.empty()
-    m.constructor.empty()
+    m.constructor.empty
 
-1. `empty` must return a value of the same Monoid
+1. `empty` must be a value of the same Monoid
 
 ### Functor
 
@@ -563,7 +562,7 @@ be equivalent to that of the derivation (or derivations).
 [`bimap`]: #bimap-method
 [`chain`]: #chain-method
 [`concat`]: #concat-method
-[`empty`]: #empty-method
+[`empty`]: #empty-value
 [`equals`]: #equals-method
 [`extend`]: #extend-method
 [`extract`]: #extract-method

--- a/id.js
+++ b/id.js
@@ -14,11 +14,7 @@ Id.prototype[fl.concat] = function(b) {
     return new Id(this.value[fl.concat](b.value));
 };
 
-// Monoid (value must also be a Monoid)
-Id[fl.empty] = function() {
-    return new Id(this.value[fl.empty] ? this.value[fl.empty]() : this.value.constructor[fl.empty]());
-};
-Id.prototype[fl.empty] = Id[fl.empty];
+// Monoid is not satisfiable since the type lacks a universal empty value
 
 // Foldable
 Id.prototype[fl.reduce] = function(f, acc) {

--- a/id_test.js
+++ b/id_test.js
@@ -14,17 +14,18 @@ const semigroup = require('./laws/semigroup');
 const setoid = require('./laws/setoid');
 const traversable = require('./laws/traversable');
 
-const {tagged} = require('daggy');
 const {of, empty, concat, equals, map} = require('.');
 
 const Id = require('./id');
 
 // Special type of sum for the type of string.
-const Sum = tagged('v');
+const Sum = function Sum(v) {
+    if (!(this instanceof Sum)) return new Sum(v);
+    this.v = v;
+};
 Sum[of] = (x) => Sum(x);
-Sum[empty] = () => Sum('');
+Sum[empty] = Sum('');
 Sum.prototype[of] = Sum[of];
-Sum.prototype[empty] = Sum[empty];
 Sum.prototype[map] = function(f) {
     return Sum(f(this.v));
 };
@@ -90,8 +91,8 @@ exports.monad = {
 };
 
 exports.monoid = {
-    leftIdentity: test((x) => monoid.leftIdentity(Id[of](Sum[empty]()))(equality)(Sum[of](x))),
-    rightIdentity: test((x) => monoid.rightIdentity(Id[of](Sum[empty]()))(equality)(Sum[of](x)))
+    leftIdentity: test((x) => monoid.leftIdentity(Sum)(equality)(x)),
+    rightIdentity: test((x) => monoid.rightIdentity(Sum)(equality)(x))
 };
 
 // Semigroup tests are broken otherwise for this.

--- a/laws/monoid.js
+++ b/laws/monoid.js
@@ -7,23 +7,23 @@ const {of, empty, concat} = require('..');
 
 ### Monoid
 
-1. `m.concat(m.empty())` is equivalent to `m` (right identity)
-2. `m.empty().concat(m)` is equivalent to `m` (left identity)
+1. `m.concat(m.constructor.empty)` is equivalent to `m` (right identity)
+2. `m.constructor.empty.concat(m)` is equivalent to `m` (left identity)
 
 **/
 
 const rightIdentity = t => eq => x => {
-    const a = t[of](x)[concat](t[empty]());
+    const a = t[of](x)[concat](t[empty]);
     const b = t[of](x);
     return eq(a, b);
 };
 
 const leftIdentity = t => eq => x => {
-    const a = t[empty]()[concat](t[of](x));
+    const a = t[empty][concat](t[of](x));
     const b = t[of](x);
     return eq(a, b);
 };
 
 module.exports = { rightIdentity
-                 , leftIdentity 
+                 , leftIdentity
                  };


### PR DESCRIPTION
This pull request introduces two changes:

  - it removes support for the `empty` instance method; and
  - it replaces the `empty` static method with an `empty` value (first proposed in #82).

As @scott-christopher pointed out in https://github.com/fantasyland/fantasy-land/pull/162#issuecomment-246651027 there are situations in which one has a type value and wants the type's identity element, but can't determine it because it's only available via the `empty` method of *values* of the type, and one doesn't know how to construct a value!

As currently specified, the Monoid type class is not very useful. We're trying to have our :cake: and eat it too, but it's not working. In order to accommodate the generalized `Monoid m =>` functions such as Scott's `Const.of` we need to *know* that `T.empty` will be available. The spec must therefore *require* this. If it's to do so, the Identity type and several others can no longer satisfy Monoid. At that point the instance method serves no purpose (beyond saving one from typing `.constructor` occasionally).

If we're to have a static method only we can no longer rely on run-time values, so `empty` needn't be a method. Rather than a nullary function which returns the identity element, it can simply *be* the identity element. Scott pointed out that one could define `empty` as a getter if one felt so inclined. :scream:
