### PR TITLE
require static methods to be defined on type representatives

### DIFF
--- a/id.js
+++ b/id.js
@@ -16,11 +16,7 @@ Id.prototype[fl.concat] = function(b) {
   return new Id(this.value[fl.concat](b.value));
 };
 
-// Monoid (value must also be a Monoid)
-Id[fl.empty] = function() {
-  return new Id(this.value[fl.empty] ? this.value[fl.empty]() : this.value.constructor[fl.empty]());
-};
-Id.prototype[fl.empty] = Id[fl.empty];
+// Monoid is not satisfiable since the type lacks a universal empty value
 
 // Foldable
 Id.prototype[fl.reduce] = function(f, acc) {
@@ -62,7 +58,6 @@ Id[fl.chainRec] = function(f, i) {
   }
   return new Id(state.value);
 };
-Id.prototype[fl.chainRec] = Id[fl.chainRec];
 
 // Extend
 Id.prototype[fl.extend] = function(f) {
@@ -73,7 +68,6 @@ Id.prototype[fl.extend] = function(f) {
 Id[fl.of] = function(a) {
   return new Id(a);
 };
-Id.prototype[fl.of] = Id[fl.of];
 
 // Comonad
 Id.prototype[fl.extract] = function() {

--- a/id_test.js
+++ b/id_test.js
@@ -23,8 +23,6 @@ const Id = require('./id');
 const Sum = tagged('v');
 Sum[of] = Sum;
 Sum[empty] = () => Sum('');
-Sum.prototype[of] = Sum[of];
-Sum.prototype[empty] = Sum[empty];
 Sum.prototype[map] = function(f) {
   return Sum(f(this.v));
 };
@@ -90,8 +88,8 @@ exports.monad = {
 };
 
 exports.monoid = {
-  leftIdentity: test(x => monoid.leftIdentity(Id[of](Sum[empty]()))(equality)(Sum[of](x))),
-  rightIdentity: test(x => monoid.rightIdentity(Id[of](Sum[empty]()))(equality)(Sum[of](x))),
+  leftIdentity: test(x => monoid.leftIdentity(Sum)(equality)(x)),
+  rightIdentity: test(x => monoid.rightIdentity(Sum)(equality)(x)),
 };
 
 // Semigroup tests are broken otherwise for this.

--- a/laws/applicative.js
+++ b/laws/applicative.js
@@ -7,29 +7,29 @@ const {of, ap} = require('..');
 
 ### Applicative
 
-1. `v.ap(a.of(x => x))` is equivalent to `v` (identity)
-2. `a.of(x).ap(a.of(f))` is equivalent to `a.of(f(x))` (homomorphism)
-3. `a.of(y).ap(u)` is equivalent to `u.ap(a.of(f => f(y)))` (interchange)
+1. `v.ap(A.of(x => x))` is equivalent to `v` (identity)
+2. `A.of(x).ap(A.of(f))` is equivalent to `A.of(f(x))` (homomorphism)
+3. `A.of(y).ap(u)` is equivalent to `u.ap(A.of(f => f(y)))` (interchange)
 
 **/
 
-const identityʹ = t => eq => x => {
-  const a = t[of](x)[ap](t[of](identity));
-  const b = t[of](x);
+const identityʹ = T => eq => x => {
+  const a = T[of](x)[ap](T[of](identity));
+  const b = T[of](x);
   return eq(a, b);
 };
 
-const homomorphism = t => eq => x => {
-  const a = t[of](x)[ap](t[of](identity));
-  const b = t[of](identity(x));
+const homomorphism = T => eq => x => {
+  const a = T[of](x)[ap](T[of](identity));
+  const b = T[of](identity(x));
   return eq(a, b);
 };
 
-const interchange = t => eq => x => {
-  const u = t[of](identity);
+const interchange = T => eq => x => {
+  const u = T[of](identity);
 
-  const a = t[of](x)[ap](u);
-  const b = u[ap](t[of](thrush(x)));
+  const a = T[of](x)[ap](u);
+  const b = u[ap](T[of](thrush(x)));
   return eq(a, b);
 };
 

--- a/laws/chainrec.js
+++ b/laws/chainrec.js
@@ -6,14 +6,14 @@ const {chain, map, chainRec} = require('..');
 
 ### ChainRec
 
-1. `t.chainRec((next, done, v) => p(v) ? d(v).map(done) : n(v).map(next), i)`
+1. `M.chainRec((next, done, v) => p(v) ? d(v).map(done) : n(v).map(next), i)`
    is equivalent to
    `(function step(v) { return p(v) ? d(v) : n(v).chain(step); }(i))`
    (equivalence)
 **/
 
-const equivalence = t => eq => p => d => n => x => {
-  const a = t[chainRec]((next, done, v) => p(v) ? d(v)[map](done) : n(v)[map](next), x);
+const equivalence = T => eq => p => d => n => x => {
+  const a = T[chainRec]((next, done, v) => p(v) ? d(v)[map](done) : n(v)[map](next), x);
   const b = (function step(v) { return p(v) ? d(v) : n(v)[chain](step); }(x));
   return eq(a, b);
 };

--- a/laws/monoid.js
+++ b/laws/monoid.js
@@ -6,20 +6,20 @@ const {of, empty, concat} = require('..');
 
 ### Monoid
 
-1. `m.concat(m.empty())` is equivalent to `m` (right identity)
-2. `m.empty().concat(m)` is equivalent to `m` (left identity)
+1. `m.concat(m.constructor.empty())` is equivalent to `m` (right identity)
+2. `m.constructor.empty().concat(m)` is equivalent to `m` (left identity)
 
 **/
 
-const rightIdentity = t => eq => x => {
-  const a = t[of](x)[concat](t[empty]());
-  const b = t[of](x);
+const rightIdentity = T => eq => x => {
+  const a = T[of](x)[concat](T[empty]());
+  const b = T[of](x);
   return eq(a, b);
 };
 
-const leftIdentity = t => eq => x => {
-  const a = t[empty]()[concat](t[of](x));
-  const b = t[of](x);
+const leftIdentity = T => eq => x => {
+  const a = T[empty]()[concat](T[of](x));
+  const b = T[of](x);
   return eq(a, b);
 };
 


### PR DESCRIPTION
Closes #176

> ## Type representatives
>
> Certain behaviours are defined from the perspective of a member of a type. Other behaviours do not require a member. Thus certain algebras require a type to provide a value-level representative (with certain properties). The Identity type, for example, could provide `Id` as its type representative: `Id :: TypeRep Identity`.
>
> If a type provides a type representative, each member of the type must have a `constructor` property which is a reference to the type representative.

I imagine there are several things I neglected to update. Let me know if you think of one. :)
