### PR TITLE
release: integrate xyz

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "devDependencies": {
     "eslint": "3.8.x",
     "nodeunit": "0.9.x",
-    "sanctuary-style": "0.2.x"
+    "sanctuary-style": "0.2.x",
+    "xyz": "1.0.x"
   },
   "repository": {
     "type": "git",
@@ -39,6 +40,9 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint --config node_modules/sanctuary-style/eslint-es6.json --env es6 --env node --rule 'max-len: [off]' -- *.js laws/*.js",
-    "test": "npm run-script lint && nodeunit id_test.js"
+    "test": "npm run-script lint && nodeunit id_test.js",
+    "release-major": "xyz --repo git@github.com:fantasyland/fantasy-land.git --increment major",
+    "release-minor": "xyz --repo git@github.com:fantasyland/fantasy-land.git --increment minor",
+    "release-patch": "xyz --repo git@github.com:fantasyland/fantasy-land.git --increment patch"
   }
 }


### PR DESCRIPTION
Using [xyz][1] to release new versions of this package will remove many sources of human error from the process. It will also make releasing new versions very convenient, as one will simply run one of the following commands:

```console
$ npm run-script release-major
```

```console
$ npm run-script release-minor
```

```console
$ npm run-script release-patch
```

This will:

1.  Verify that the current branch is `master`.
2.  Verify that the working directory contains no unstaged changes.
3.  Present a confirmation prompt.
4.  Verify that `npm test` exits successfully.
5.  Update the `"version"` field in __package.json__.
6.  Commit the change to __package.json__ with the message `Version X.Y.Z`.
7.  Create an annotated tag named `vX.Y.Z` pointing to the commit.
8.  Push the commit and the tag—atomically—to GitHub.
9.  Run `npm publish`.

I've used xyz countless times over the past two and a half years. It's rock solid. It's not Windows-compatible, but I imagine that's not a problem.


[1]: https://github.com/davidchambers/xyz
