### PR TITLE
Use uppercase letters for TypeRep

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ A value which has a Semigroup must provide a `concat` method. The
 A value that implements the Monoid specification must also implement
 the [Semigroup](#semigroup) specification.
 
-1. `m.concat(m.constructor.empty())` is equivalent to `m` (right identity)
-2. `m.constructor.empty().concat(m)` is equivalent to `m` (left identity)
+1. `m.concat(M.empty())` is equivalent to `m` (right identity)
+2. `M.empty().concat(m)` is equivalent to `m` (left identity)
 
 #### `empty` method
 
@@ -386,8 +386,8 @@ Given a value `m`, one can access its type representative via the
 A value that implements the Monad specification must also implement
 the [Applicative](#applicative) and [Chain](#chain) specifications.
 
-1. `m.of(a).chain(f)` is equivalent to `f(a)` (left identity)
-2. `m.chain(m.of)` is equivalent to `m` (right identity)
+1. `M.of(a).chain(f)` is equivalent to `f(a)` (left identity)
+2. `m.chain(M.of)` is equivalent to `m` (right identity)
 
 ### Extend
 

--- a/laws/monad.js
+++ b/laws/monad.js
@@ -6,8 +6,8 @@ const {of, chain} = require('..');
 
 ### Monad
 
-1. `m.of(a).chain(f)` is equivalent to `f(a)` (left identity)
-2. `m.chain(m.of)` is equivalent to `m` (right identity)
+1. `M.of(a).chain(f)` is equivalent to `f(a)` (left identity)
+2. `m.chain(M.of)` is equivalent to `m` (right identity)
 
 **/
 

--- a/laws/monoid.js
+++ b/laws/monoid.js
@@ -6,8 +6,8 @@ const {of, empty, concat} = require('..');
 
 ### Monoid
 
-1. `m.concat(m.constructor.empty())` is equivalent to `m` (right identity)
-2. `m.constructor.empty().concat(m)` is equivalent to `m` (left identity)
+1. `m.concat(M.empty())` is equivalent to `m` (right identity)
+2. `M.empty().concat(m)` is equivalent to `m` (left identity)
 
 **/
 


### PR DESCRIPTION
In Applicative we are using `A` but in monad and monoid we still use `m`.
in case of Monad one might think that we are accessing `of` on instance.
monoid law is technically correct but I think sticking to one way of doing thing is better so i have updated it as well.