### PR TITLE
update Extend and Comonad dependencies to match figure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ structures:
 * [Bifunctor](#bifunctor)
 * [Profunctor](#profunctor)
 
-<img src="figures/dependencies.png" width="888" height="340" />
+<img src="figures/dependencies.png" width="888" height="347" />
 
 ## General
 
@@ -457,6 +457,8 @@ the [Applicative](#applicative) and [Chain](#chain) specifications.
 
 ### Extend
 
+A value that implements the Extend specification must also implement the [Functor](#functor) specification.
+
 1. `w.extend(g).extend(f)` is equivalent to `w.extend(_w => f(_w.extend(g)))`
 
 #### `extend` method
@@ -481,11 +483,10 @@ method takes one argument:
 
 ### Comonad
 
-A value that implements the Comonad specification must also implement the [Functor](#functor) and [Extend](#extend) specifications.
+A value that implements the Comonad specification must also implement the [Extend](#extend) specification.
 
 1. `w.extend(_w => _w.extract())` is equivalent to `w`
 2. `w.extend(f).extract()` is equivalent to `f(w)`
-3. `w.extend(f)` is equivalent to `w.extend(x => x).map(f)`
 
 #### `extract` method
 

--- a/laws/comonad.js
+++ b/laws/comonad.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {identity} = require('fantasy-combinators');
-const {extend, map, extract} = require('..');
+const {extend, extract} = require('..');
 
 /**
 
@@ -9,7 +9,6 @@ const {extend, map, extract} = require('..');
 
 1. `w.extend(_w => _w.extract())` is equivalent to `w`
 2. `w.extend(f).extract()` is equivalent to `f(w)`
-3. `w.extend(f)` is equivalent to `w.extend(x => x).map(f)`
 
 **/
 
@@ -25,10 +24,4 @@ const rightIdentity = t => eq => x => {
   return eq(a, b);
 };
 
-const associativity = t => eq => x => {
-  const a = t(x)[extend](identity);
-  const b = t(x)[extend](identity)[map](identity);
-  return eq(a, b);
-};
-
-module.exports = {leftIdentity, rightIdentity, associativity};
+module.exports = {leftIdentity, rightIdentity};

--- a/test.js
+++ b/test.js
@@ -67,7 +67,6 @@ exports.chainRec = {
 exports.comonad = {
   leftIdentity: test(comonad.leftIdentity(Id[fl.of])(equality)),
   rightIdentity: test(comonad.rightIdentity(Id[fl.of])(equality)),
-  associativity: test(comonad.associativity(Id[fl.of])(equality)),
 };
 
 exports.extend = {


### PR DESCRIPTION
Thank you for pointing out this inconsistency, @jlmorgan.

If Extend really *does* depend on Functor we should update the description of Extend rather than merge this pull request.
