### PR TITLE
Add short-circuiting left and right fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,27 +338,108 @@ the [Applicative](#applicative) and [Plus](#plus) specifications.
 
 ### Foldable
 
-1. `u.reduce` is equivalent to `u.reduce((acc, x) => acc.concat([x]), []).reduce`
+1. `u` is equivalent to `u.foldl((acc, x) => acc.concat([x]), [])`
+2. `u.foldr(f, acc)` is equivalent to `u.foldl((a, b) => (c) => a(f(c,
+   b)), id)(acc)`
+3. `u.shortFoldl((acc, x) => {done: false, value: f(acc, x)},
+   initial)` is equivalent to `u.foldl(f, initial)`
+4. `u.shortFoldr((acc, x) => {done: false, value: f(x, acc)},
+   initial)` is equivalent to `u.foldr(f, initial)`
 
-#### `reduce` method
+#### `foldl` method
 
 ```hs
-reduce :: Foldable f => f a ~> ((b, a) -> b, b) -> b
+foldl :: Foldable f => f a ~> (b, a) -> b ~> b -> b
 ```
 
-A value which has a Foldable must provide a `reduce` method. The `reduce`
+A value which has a Foldable must provide a `foldl` method. The `foldl`
 method takes two arguments:
 
-    u.reduce(f, x)
+    u.foldl(f, x)
 
 1. `f` must be a binary function
 
-    1. if `f` is not a function, the behaviour of `reduce` is unspecified.
-    2. The first argument to `f` must be the same type as `x`.
+    1. if `f` is not a function, the behaviour of `foldl` is unspecified.
+    2. The _first_ argument to `f` must be the same type as `x`.
     3. `f` must return a value of the same type as `x`.
     4. No parts of `f`'s return value should be checked.
 
-1. `x` is the initial accumulator value for the reduction
+2. `x` is the initial accumulator value for the fold
+
+    1. No parts of `x` should be checked.
+
+#### `foldr`
+
+```hs
+foldr :: Foldable f => f a ~> (a, b) -> b ~> b -> b
+```
+
+A value which has a Foldable must provide a `foldr` method. The `foldr`
+method takes two arguments:
+
+    u.foldr(f, x)
+
+1. `f` must be a binary function
+
+    1. if `f` is not a function, the behaviour of `foldr` is unspecified.
+    2. The _second_ argument to `f` must be the same type as `x`.
+    3. `f` must return a value of the same type as `x`.
+    4. No parts of `f`'s return value should be checked.
+
+2. `x` is the initial accumulator value for the fold
+
+    1. No parts of `x` should be checked.
+
+#### `shortFoldl`
+
+```hs
+shortFoldl :: Foldable f => f a ~> ((b, a) -> {done :: Boolean, value :: b}) ~> b -> b
+```
+
+A value which has a Foldable must provide a `shortFoldl` method. The `shortFoldl`
+method takes two arguments:
+
+    u.shortFoldl(f, x)
+
+1. `f` must be a binary function
+
+    1. if `f` is not a function, the behaviour of `foldl` is unspecified.
+    2. The _first_ argument to `f` must be the same type as `x`.
+    3. `f` must return an object with two properties, `done` and
+       `value`. `done` must be a boolean and `value` must be of the
+       same type as `x`.
+    4. No parts of the `value` property returned by `f` should be
+       checked.
+    5. If `f` returns an object `o` where `o.done === true` then
+       `o.value` _must_ be the value returned by `shortFoldl`.
+
+1. `x` is the initial accumulator value for the fold
+
+    1. No parts of `x` should be checked.
+
+#### `shortFoldr`
+
+```hs
+shortFoldr :: Foldable f => f a ~> ((a, b) -> {done :: Boolean, value :: b}) ~> b -> b
+```
+
+A value which has a Foldable must provide a `shortFoldr` method. The `shortFoldr`
+method takes two arguments:
+
+    u.shortFoldr(f, x)
+
+1. `f` must be a binary function
+
+    1. if `f` is not a function, the behaviour of `foldl` is unspecified.
+    2. The _second_ argument to `f` must be the same type as `x`.
+    3. `f` must return an object with two properties, `done` and
+       `value`. `done` must be a boolean and `value` must be of the
+       same type as `x`.
+    4. No parts of the `value` property returned by `f` should be checked.
+    5. If `f` returns an object `o` where `o.done === true` then
+       `o.value` _must_ be the value returned by `shortFoldr`.
+
+1. `x` is the initial accumulator value for the fold
 
     1. No parts of `x` should be checked.
 
@@ -635,7 +716,7 @@ to implement certain methods then derive the remaining methods. Derivations:
     function(m) { return m.chain(f => this.map(f)); }
     ```
 
-  - [`reduce`][] may be derived as follows:
+  - [`foldl`][] may be derived as follows:
 
     ```js
     function(f, acc) {
@@ -701,7 +782,7 @@ be equivalent to that of the derivation (or derivations).
 [`map`]: #map-method
 [`of`]: #of-method
 [`promap`]: #promap-method
-[`reduce`]: #reduce-method
+[`foldl`]: #foldl-method
 [`sequence`]: #sequence-method
 
 ## Alternatives


### PR DESCRIPTION
This PR primarily adds a short-circuiting left and right fold to the Foldable specification. The changes proposed are adapted from my experiments in [Jabz](https://github.com/Funkia/jabz).

## The problem

Fantasy Land currently specifies only a strict left fold. This has the following disadvantages:

* Infinite data structures cannot implement the Foldable specification in any meaningful way. This is in contrast to Haskell's Foldable typeclass which works fine with infinite structures due to lazyness. Even JavaScript's Iterator specification can handle infinite structures. 
* Many operations that can be carried out on Foldables run with suboptimal performance with a strict fold. Consider for instance the following function:

```js
function find(predicate, foldable) {
  return foldable.reduce((acc, a) => {
    if (isJust(acc)) {
      return acc;
    } else if (predicate(a) === true) {
      return just(a);
    } else {
      return nothing;
    }
  }, nothing);
}
```

It finds the first element in a Foldable that satisfies the predicate. But, it will _always_ traverse the entire Foldable. Ideally, we would like the function to stop as soon as a matching element is found.

## The solution

This PR adds two additional methods to the Foldable specification. The first is named `shortFoldl` and the second `shortFoldr`. They are added along with two laws and a description of their behavior. The functions are similar to normal folds with the difference that the folding function must return an object of the type:

```ts
type Result<A> = {
  done: boolean,
  value: A
}
```

The `value` property is what would typically be returned only and the `done` property indicates whether or not the fold should stop. Given this the above `find` function could be implemented like this:

```js
function find(f, foldable) {
  return foldable.shortFoldl((_, a) => f(a) ? {done: true, value: just(a)} : {done: false, value: nothing}, nothing);
}
```

This implementation of `find` short-circuits as soon as a satisfying value is found. Furthermore, it will also work for infinite data-structures.

`shortFoldr` is added so that functions like `findLast` can also be implemented with optimal performance.

## Other changes

This PR also adds a strict right fold to the Foldable specification. The new 2. law ensures that this right fold behaves symmetric to the left fold. The law is a bit tricky I think. But I've convinced myself that it is correct with the following concrete example

```js
const id = a => a;
const f = (m, n) => m - n;
const u = [1, 2, 3, 4, 5];
const acc = 4;
console.log(u.reduceRight(f, acc));
console.log(u.reduce((a, b) => (c) => a(f(c, b)), id)(acc));
```

# About the names

Since this is a breaking change anyway I have decided to rename `reduce` to `foldl`. If renaming `reduce` is controversial I suggest this alternative naming:

| Current name in PR | Alternative proposal |
| --- | --- |
| foldl | reduce (i.e. no renaming) |
| foldr | reduceRight |
| shortFoldl | shortReduce |
| shortFoldr | shortReducRight |

But I prefer the current naming for the following reasons:

* It better matches the name of the abstraction (Foldable)
* `foldl` is explicit about the direction of the fold while `reduce` is not.
* `foldl` and `foldr` has a nice symmetry that reflects the actual symmetry of the functions.

## Why not use thunks

In Jabz I also experimented with versions of `foldr` and `foldl` made lazy by using thunks. However forcing a thunk must be in the form of a function invocation and this resulted in the lazy `foldr` and `foldl` not being stack safe (i.e. they would overflow the stack for large data-structures).

## Final remarks

I'd love to hear what you all think of these changes.