### PR TITLE
Fix: map derivated from ap and of

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ to implement certain methods then derive the remaining methods. Derivations:
   - [`map`][] may be derived from [`ap`][] and [`of`][]:
 
     ```js
-    function(f) { return this.ap(this.of(f)); }
+    function(f) { return this.of(f).ap(this); }
     ```
 
   - [`map`][] may be derived from [`chain`][] and [`of`][]:


### PR DESCRIPTION
it may be this from what i understand. for example 

``` js
const add = x => x + 1
[1, 2, 3, 4, 5].map(add)      // [2, 3, 4, 5, 6]
Array.of(add).ap([1, 2, 3, 4, 5]) // [2, 3, 4, 5, 6]
```