### PR TITLE
Complete the implementations for primitive JS types

### DIFF
--- a/internal/func.js
+++ b/internal/func.js
@@ -1,13 +1,23 @@
 'use strict';
 
 const fl = require('../');
-const equality = (x, y) => typeof x[fl.equals] === 'function' ? x[fl.equals](y) : x === y;
+
+const equality = (x, y) =>
+  typeof x[fl.equals] === 'function'
+  ? x[fl.equals](y)
+  : x === y;
+
 const lte = (x, y) => {
-  if (typeof y[fl.lte] === 'function') return y[fl.lte](x);
+  if (typeof x[fl.lte] === 'function') {
+    return x[fl.lte](y);
+  }
 
   const typeX = typeof x;
   const typeY = typeof y;
-  return typeX === typeY && (typeX === 'string' || typeX === 'number') && x <= y;
+
+  return typeX === typeY
+    && ['string', 'number'].indexOf(typeX) !== -1
+    && x <= y;
 };
 
 module.exports = {

--- a/internal/patch.js
+++ b/internal/patch.js
@@ -3,31 +3,168 @@
 const fl = require('..');
 
 module.exports = () => {
-  String.prototype[fl.concat] = String.prototype.concat;
-  Array.prototype[fl.equals] = function(y) {
-    return this.length === y.length && this.join('') === y.join('');
+  // Array
+
+  Array.prototype[fl.equals] = function(that) {
+    return this.length === that.length &&
+      this.every((x, i) => x[fl.equals](that[i]));
   };
+
+  Array.prototype[fl.lte] = function(that) {
+    if (this.length === 0) return true;
+    if (that.length === 0) return false;
+
+    return this[0][fl.lte](that[0])
+      ? this[0][fl.equals](that[0])
+        ? this.slice(1)[fl.lte](that.slice(1))
+        : true
+      : false;
+  };
+
+  Array.prototype[fl.concat] = Array.prototype.concat;
+
+  Array[fl.empty] = () => [];
+
   Array.prototype[fl.map] = function(f) {
     return this.map(x => f(x));
   };
+
   Array.prototype[fl.ap] = function(fs) {
     return fs[fl.chain](f => this.map(f));
   };
-  Array.prototype[fl.chain] = function(f) {
-    return [].concat(this.map(f));
+
+  Array[fl.of] = x => [x];
+
+  Array.prototype[fl.alt] = Array.prototype.concat;
+
+  Array[fl.zero] = Array[fl.empty];
+
+  Array.prototype[fl.reduce] = function(f, init) {
+    return this.reduce((acc, x) => f(acc, x), init);
   };
-  Array.prototype[fl.reduce] = function(f, x) {
-    return this.reduce((x, y) => f(x, y), x);
-  };
-  Array.prototype[fl.concat] = Array.prototype.concat;
+
   Array.prototype[fl.traverse] = function(typeRep, f) {
-    return this[fl.map](f)[fl.reduce](
-      (ys, x) => ys[fl.ap](x[fl.map](y => z => z[fl.concat](y))),
+    return this.map(f).reduce(
+      (ys, x) => ys[fl.ap](x[fl.map](
+        y => z => z[fl.concat](y)
+      )),
+
       typeRep[fl.of]([])
     );
   };
-  Array.prototype[fl.alt] = function(b) {
-    return this.concat(b);
+
+  Array.prototype[fl.chain] = function(f) {
+    return [].concat(... this.map(f));
   };
-  Array[fl.zero] = () => [];
+
+  Array.prototype[fl.extend] = function(f) {
+    return [f(this)];
+  };
+
+  // Boolean
+
+  Boolean.prototype[fl.equals] = function(that) {
+    return this === that;
+  }
+
+  Boolean.prototype[fl.lte] = function(that) {
+    return this ? that : true;
+  }
+
+  // Function
+
+  Function.prototype[fl.concat] = function(that) {
+    return x => this(x).concat(that(x));
+  };
+
+  /* Can't write fl.empty as we don't know the monoid :( */
+
+  Function.prototype[fl.map] = function(that) {
+    return x => that(this(x));
+  };
+
+  // ONLY FOR UNARIES.
+  Function.prototype[fl.ap] = function(fs) {
+    return x => fs(x)(this(x));
+  };
+
+  Function[fl.of] = x => _ => x;
+
+  Function.prototype[fl.alt] = function(that) {
+    return x => this(x)[fl.alt](that(x))
+  };
+
+  /* Can't write fl.zero as we don't know the alt :( */
+
+  Function.prototype[fl.chain] = function(f) {
+    return x => f(this(x))(x);
+  };
+
+  Function.prototype[fl.promap] = function(f, g) {
+    return f[fl.map](this)[fl.map](g);
+  };
+
+  // Number
+
+  Number.prototype[fl.equals] = function(that) {
+    return this === that;
+  };
+
+  Number.prototype[fl.lte] = function(that) {
+    return this <= that;
+  };
+
+  // Object
+
+  Object.prototype[fl.equals] = function(that) {
+    const keys = Object.keys(this)
+
+    return keys[fl.equals](Object.keys(that))
+      && keys.every(k => this[k][fl.equals](that[k]));
+  };
+
+  Object.prototype[fl.concat] = function(that) {
+    return Object.assign({}, this, that);
+  };
+
+  Object[fl.empty] = () => ({});
+
+  // Only makes sense for StrMaps!
+  Object.prototype[fl.map] = function(f) {
+    const result = {};
+
+    Object.keys(this).forEach(
+      k => result[k] = f(this[k])
+    );
+
+    return result;
+  };
+
+  // A function is really just (usually necessary) sugar
+  // on an explicit mapping, which is a dictionary. Not
+  // 100% sold on this implementation because of keys
+  // e.g. (what if f :: a -> (x -> a)), but please review.
+  Object.prototype[fl.promap] = function(f, g) {
+    const result = {};
+
+    Object.keys(this).forEach(
+      k => result[f(k)] = g(this[k])
+    );
+
+    return result;
+  };
+
+  // String
+
+  String.prototype[fl.equals] = function(that) {
+    return this === that;
+  };
+
+  String.prototype[fl.lte] = function(that) {
+    return this <= that;
+  };
+
+  String.prototype[fl.concat] = String.prototype.concat;
+
+  String[fl.empty] = () => '';
 };

--- a/internal/patch.js
+++ b/internal/patch.js
@@ -65,11 +65,11 @@ module.exports = () => {
 
   Boolean.prototype[fl.equals] = function(that) {
     return this === that;
-  }
+  };
 
   Boolean.prototype[fl.lte] = function(that) {
     return this ? that : true;
-  }
+  };
 
   // Function
 
@@ -91,7 +91,7 @@ module.exports = () => {
   Function[fl.of] = x => _ => x;
 
   Function.prototype[fl.alt] = function(that) {
-    return x => this(x)[fl.alt](that(x))
+    return x => this(x)[fl.alt](that(x));
   };
 
   /* Can't write fl.zero as we don't know the alt :( */
@@ -117,7 +117,7 @@ module.exports = () => {
   // Object
 
   Object.prototype[fl.equals] = function(that) {
-    const keys = Object.keys(this)
+    const keys = Object.keys(this);
 
     return keys[fl.equals](Object.keys(that))
       && keys.every(k => this[k][fl.equals](that[k]));


### PR DESCRIPTION
Hello! I noticed the `internal/patch.js` file was looking a bit neglected, so I've added in all the sensible implementations I could think of for the primitive types. There are at least a couple we can't add because of limitations around type inference, but I left comments to point them out.

I'd also like to open the discussion as to whether `Object` can be considered a `Profunctor` type by the given implementation. I'm concerned that the keys in native JS objects aren't as flexible as one would hope, and you're obviously going to get funny behaviour with non-primitive types due to pointer lookups and other ugliness. I'm not optimistic, which is a shame :(

I've gone through every one and tested it in the console (and consequently fixed the `chain` implementation for `Array`, which was actually `map`). What do people think? :)