### PR TITLE
Flip arguments in compose type signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ A value which has an Ord must provide a `lte` method. The
 #### `compose` method
 
 ```hs
-compose :: Semigroupoid c => c i j ~> c j k -> c i k
+compose :: Semigroupoid c => c j k ~> c i j -> c i k
 ```
 
 A value which has a Semigroupoid must provide a `compose` method. The


### PR DESCRIPTION
In PureScript
```hs
> append [1] [2] == [1] <> [2]
true

> (compose (_ + 1) (_ / 3)) 4 == ((_ + 1) <<< (_ / 3)) 4
true
```
I think I made a mistake with the signature for `compose`. It should be
```hs
Semigroupoid c => c j k ~> c i j -> c i k
```
not
```hs
Semigroupoid c => c i j ~> c j k -> c i k
```