### PR TITLE
docs(implementations.md): add ramda-adjunct

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -29,6 +29,7 @@ Here are a list of implementations that live in Fantasy Land:
 * [List in JS](https://github.com/PandaNoir/List-in-JS/) implements Setoid, Semigroup, Monoid, Functor, Applicative, Foldable, Traversable, Chain and Monad.
 * [Sanctuary](https://github.com/plaid/sanctuary) is a refuge from unsafe JavaScript. It provides FL-compatible Either and Maybe types.
 * [Fluture](https://github.com/Avaq/Fluture) is a high-performance monadic alternative to Promises.
+* [Ramda Adjunct](https://github.com/char0n/ramda-adjunct) is a community-maintained extension of Ramda
 
 Conforming implementations are encouraged to promote the Fantasy Land logo:
 


### PR DESCRIPTION
Ramda adjunct contains functional utils  for monadic types from monet, ramda-fantasy and contains reference implementation of Identity monad compliant with fantasy-land.