### PR TITLE
Add zoom as an implementation.

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -30,6 +30,7 @@ Here are a list of implementations that live in Fantasy Land:
 * [Sanctuary](https://github.com/plaid/sanctuary) is a refuge from unsafe JavaScript. It provides FL-compatible Either and Maybe types.
 * [Fluture](https://github.com/Avaq/Fluture) is a high-performance monadic alternative to Promises.
 * [Ramda Adjunct](https://github.com/char0n/ramda-adjunct) is a community-maintained extension of Ramda
+* [Zoom JS](https://github.com/dustinws/zoom) is a collection of common monads and monad transformers for javascript.
 
 Conforming implementations are encouraged to promote the Fantasy Land logo:
 


### PR DESCRIPTION
Hello all,

I've added a library I maintain in my downtime to the implementations file, let me know what you guys think!

So far it supports a few different types, with a strong focus on documentation and examples. Since it's just me working on it right now, the examples still have a long way to go. In the documentation, each type is explicit about the fantasy types they conform to.

Thanks!

If you would like a link to the library without looking through the diff, [here it is](https://dustinws.github.io/zoom/index.html).
