### PR TITLE
readme: replace problematic definition of promise equivalence

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ have dependencies on other algebras which must be implemented.
     The definition should ensure that the two values can be safely swapped out in a program that respects abstractions. For example:
     - Two lists are equivalent if they are equivalent at all indices.
     - Two plain old JavaScript objects, interpreted as dictionaries, are equivalent when they are equivalent for all keys.
-    - Two promises are equivalent when they yield equivalent values.
+    - Two values are equivalent if they are [referentially transparent](https://en.wikipedia.org/wiki/Referential_transparency).
     - Two functions are equivalent if they yield equivalent outputs for equivalent inputs.
 
 ## Type signature notation


### PR DESCRIPTION
I've listed @safareli as co-author since he suggested this change in <https://github.com/fantasyland/fantasy-land/issues/211#issuecomment-267304326> back in 2016!
