### PR TITLE
Fixes Folktale description

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -30,7 +30,7 @@ Here are a list of implementations that live in Fantasy Land:
 * [Sanctuary](https://github.com/plaid/sanctuary) is a refuge from unsafe JavaScript. It provides FL-compatible Either and Maybe types.
 * [Fluture](https://github.com/Avaq/Fluture) is a high-performance monadic alternative to Promises.
 * [Ramda Adjunct](https://github.com/char0n/ramda-adjunct) is a community-maintained extension of Ramda
-* [Folktale](https://folktale.origamitower.com/) implements Maybe, Result, Validation, Task and Future as FL-compatible Monads.
+* [Folktale](https://folktale.origamitower.com/) implements Maybe, Result, Validation, Task and Future as FL-compatible types.
 
 Conforming implementations are encouraged to promote the Fantasy Land logo:
 


### PR DESCRIPTION
Previously it mentioned Maybe, Result, Validation, Task, and Future as "FL-compatible Monads". Validation doesn't implement Monad and the other types implement other FL interfaces as well. FL-compatible types is a more generic (if vague-ish) description.