### PR TITLE
Add Monastic to the list of conformant implementations

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -31,6 +31,7 @@ Here are a list of implementations that live in Fantasy Land:
 * [Fluture](https://github.com/Avaq/Fluture) is a high-performance monadic alternative to Promises.
 * [Ramda Adjunct](https://github.com/char0n/ramda-adjunct) is a community-maintained extension of Ramda
 * [Folktale](https://folktale.origamitower.com/) implements Maybe, Result, Validation, Task and Future as FL-compatible types.
+* [Monastic](https://github.com/wearereasonablepeople/monastic) implements a Fantasy Land 3 compliant State Monad.
 
 Conforming implementations are encouraged to promote the Fantasy Land logo:
 


### PR DESCRIPTION
Monastic was made in response to https://github.com/fantasyland/fantasy-states
being archived, and as a learning exercise. It's tested for compliance with fantasy-laws.