### PR TITLE
use correct fields for entry points in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "/package.json"
   ],
   "main": "index.js",
-  "types": "index.d.ts",
-  "module": "index.mjs",
+  "exports": {
+    "require": "./index.js",
+    "import": "./index.mjs"
+  },
   "scripts": {
     "doctest": "sanctuary-doctest",
     "generate-es": "scripts/generate-es",


### PR DESCRIPTION
The fantasy-land keys are currently not importable when using esmodules
available in node 12 and forward, these changes solve the problem.

The module field has been removed since it serves no purpose and is not
recognized by node. Exports field has been added accoding to the
official node js documentation:
https://nodejs.org/api/packages.html#packages_conditional_exports

Main field is kept for legacy suppoert of node versions 12 and earlier.

The types field has been removed since it is not needed. Typescript will
find the definitions anyway when using both import and require.

This should in theory not be breaking but it is difficult to know if any
use case or build tool relies on the undocumented conventions that
previoulsy existed in package.json.