### PR TITLE
Improve portability of the UMD build

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,10 @@
         "no-undef": ["off"],
         "no-unused-vars": ["off"]
       }
+    },
+    {
+      "files": "index.js",
+      "globals": {"globalThis": false}
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -28,10 +28,14 @@
   };
 
   /* istanbul ignore else */
-  if (typeof module === 'object' && typeof module.exports === 'object') {
+  if (
+    typeof module === 'object' &&
+    module != null &&
+    typeof module.exports === 'object'
+  ) {
     module.exports = mapping;
   } else {
-    self.FantasyLand = mapping;
+    globalThis.FantasyLand = mapping;
   }
 
 } ());

--- a/scripts/generate-js
+++ b/scripts/generate-js
@@ -11,10 +11,14 @@ cat >index.js <<EOF
   };
 
   /* istanbul ignore else */
-  if (typeof module === 'object' && typeof module.exports === 'object') {
+  if (
+    typeof module === 'object' &&
+    module != null &&
+    typeof module.exports === 'object'
+  ) {
     module.exports = mapping;
   } else {
-    self.FantasyLand = mapping;
+    globalThis.FantasyLand = mapping;
   }
 
 } ());


### PR DESCRIPTION
This PR:

- replaces `self` with `globalThis`
- makes detection of CommonJS environments more robust

[`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) is the official way to refer to the global scope and is supported by almost all environments:

| engine          | self | globalThis |
|-----------------|------|------------|
| Node.js         | ✖    | ✔          |
| QuickJS         | ✖    | ✔          |
| SpiderMonkey    | ✖    | ✔          |
| Modern browsers | ✔    | ✔          |
| Deno            | ✔    | ✔          |
| IE11            | ✔    | ✖          |

The notable exception is IE11, which will need to use a [polyfill](https://github.com/search?q=globalThis+polyfill&s=stars). If IE11 support was previously promised or assumed, then this would be a breaking change.