### PR TITLE
update package exports for latest TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "main": "index.js",
   "exports": {
+    "types": "./index.d.ts",
     "require": "./index.js",
     "import": "./index.mjs"
   },


### PR DESCRIPTION
This according to the new standard available in TypeScript 4.8.0 and
forward.
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

Here we go again. Trying to stay up to date with the latest :)